### PR TITLE
fix: Initialize msg variable in onUploadComplete

### DIFF
--- a/bot/helper/listeners/tasks_listener.py
+++ b/bot/helper/listeners/tasks_listener.py
@@ -234,6 +234,7 @@ class TaskListener(TaskConfig):
             await gather(update_status_message(self.message.chat.id), RCTransfer.upload(up_path, size))
 
     async def onUploadComplete(self, link, size, files, folders, mime_type, rclonePath='', dir_id=''):
+        msg = ''
         if self.isSuperChat and config_dict['INCOMPLETE_TASK_NOTIFIER'] and DATABASE_URL:
             await DbManager().rm_complete_task(self.message.link)
 


### PR DESCRIPTION
The `msg` variable in the `onUploadComplete` method in `tasks_listener.py` was not initialized if the `LINK_LOG` setting was disabled, leading to an `UnboundLocalError`.

This commit initializes `msg` to an empty string at the beginning of the method to prevent this error.