### PR TITLE
Fix unresponsive tasks and other bugs

### DIFF
--- a/bot/helper/listeners/tasks_listener.py
+++ b/bot/helper/listeners/tasks_listener.py
@@ -167,11 +167,19 @@ class TaskListener(TaskConfig):
             self.name = ospath.basename(up_dir)
             size = await get_path_size(up_dir)
 
+            o_files, m_size = [], []
+            result = await self.proceedSplit(up_dir, m_size, o_files, size, self.gid)
+            if not result:
+                return
+
+            for s in m_size:
+                size -= s
+
             LOGGER.info(f'Leech Name: {self.name}')
             tg = TgUploader(self, up_dir, size)
             async with task_dict_lock:
                 task_dict[self.mid] = TelegramStatus(self, tg, size, self.gid, 'up')
-            await gather(update_status_message(self.message.chat.id), tg.upload([], []))
+            await gather(update_status_message(self.message.chat.id), tg.upload(o_files, m_size))
             return
 
         if not self.compress and not self.extract and not self.vidMode:

--- a/bot/helper/mirror_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_utils/upload_utils/telegram_uploader.py
@@ -421,8 +421,11 @@ class TgUploader:
             if link:
                 self._buttons.button_link(mode, await sync_to_async(short_url, link, self._listener.user_id), 'header')
         self._send_msg = await bot.get_messages(self._send_msg.chat.id, self._send_msg.id)
-        if (buttons := self._buttons.build_menu(2)) and (cmsg := await self._send_msg.edit_reply_markup(buttons)):
-            self._send_msg = cmsg
+        try:
+            if (buttons := self._buttons.build_menu(2)) and (cmsg := await self._send_msg.edit_reply_markup(buttons)):
+                self._send_msg = cmsg
+        except Exception as e:
+            LOGGER.error('Error while editing reply markup: %s', e)
 
     def _get_input_media(self, subkey: str, key: str):
         imlist = []

--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -111,16 +111,25 @@ async def run_ffmpeg(path, output_path, video_stream, audio_streams, subtitle_st
 
     parser_task = bot_loop.create_task(_parser())
 
+    # Log stderr to prevent pipe buffer from filling up
+    async def _log_stderr():
+        async for line in process.stderr:
+            LOGGER.info(f"ffmpeg: {line.decode().strip()}")
+
+    stderr_task = bot_loop.create_task(_log_stderr())
+
     await process.wait()
+
     parser_task.cancel()
+    stderr_task.cancel()
 
     if process.returncode == 0:
         LOGGER.info(f"Video processing successful: {output_path}")
         return output_path
     else:
-        stderr_output = await process.stderr.read()
-        LOGGER.error(f"ffmpeg error: {stderr_output.decode().strip()}")
-        await listener.onUploadError(f"ffmpeg error: {stderr_output.decode().strip()}")
+        # No need to read stderr here as it's already logged
+        LOGGER.error(f"ffmpeg exited with non-zero return code: {process.returncode}")
+        await listener.onUploadError(f"ffmpeg exited with non-zero return code: {process.returncode}")
         return None
 
 


### PR DESCRIPTION
This commit addresses several issues related to task processing, including:
- A deadlock in the ffmpeg process that caused tasks to become unresponsive.
- A bug where files were not being split after video processing.
- A bug that could cause files to be uploaded twice.