### PR TITLE
Fix task processing bugs and improve robustness

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -175,20 +175,24 @@ async def get_audio_thumb(audio_file):
 
 
 async def create_thumbnail(video_file, duration):
-    des_dir = 'thumbnails'
-    await makedirs(des_dir, exist_ok=True)
-    des_dir = ospath.join(des_dir, f'{time()}.jpg')
-    if duration is None:
-        duration = (await get_media_info(video_file))[0]
-    if duration == 0:
-        duration = 3
-    duration = duration // 2
-    cmd = [FFMPEG_NAME, '-hide_banner', '-loglevel', 'error', '-ss', f'{duration}', '-i', video_file, '-vf', 'thumbnail', '-frames:v', '1', des_dir]
-    _, err, code = await cmd_exec(cmd)
-    if code != 0 or not await aiopath.exists(des_dir):
-        LOGGER.error('Error while extracting thumbnail from video. Name: %s stderr: %s', video_file, err)
+    try:
+        des_dir = 'thumbnails'
+        await makedirs(des_dir, exist_ok=True)
+        des_dir = ospath.join(des_dir, f'{time()}.jpg')
+        if duration is None:
+            duration = (await get_media_info(video_file))[0]
+        if duration == 0:
+            duration = 3
+        duration = duration // 2
+        cmd = [FFMPEG_NAME, '-hide_banner', '-loglevel', 'error', '-ss', f'{duration}', '-i', video_file, '-vf', 'thumbnail', '-frames:v', '1', des_dir]
+        _, err, code = await cmd_exec(cmd)
+        if code != 0 or not await aiopath.exists(des_dir):
+            LOGGER.error('Error while extracting thumbnail from video. Name: %s stderr: %s', video_file, err)
+            return None
+        return des_dir
+    except Exception as e:
+        LOGGER.error(f"Exception in thumbnail extraction for {video_file}: {e}")
         return None
-    return des_dir
 
 
 async def split_file(path, size, dirpath, split_size, listener, obj, start_time=0, i=1, inLoop=False, multi_streams=True):

--- a/bot/helper/ext_utils/task_manager.py
+++ b/bot/helper/ext_utils/task_manager.py
@@ -62,19 +62,20 @@ async def check_running_tasks(mid: int, state='dl'):
     state_limit = (config_dict['QUEUE_DOWNLOAD'] if state == 'dl' else config_dict['QUEUE_UPLOAD'])
     event = None
     is_over_limit = False
-    if all_limit or state_limit:
-        async with queue_dict_lock:
-            if state == 'up' and mid in non_queued_dl:
-                non_queued_dl.remove(mid)
-            dl_count, up_count = len(non_queued_dl), len(non_queued_up)
-            is_over_limit = (all_limit and dl_count + up_count >= all_limit and (not state_limit or dl_count >= state_limit)) or (state_limit and dl_count >= state_limit)
-            if is_over_limit:
-                event = Event()
-                if state == 'dl':
-                    queued_dl[mid] = event
-                else:
-                    queued_up[mid] = event
-
+    async with queue_dict_lock:
+        if state == 'up' and mid in non_queued_dl:
+            non_queued_dl.remove(mid)
+        dl_count, up_count = len(non_queued_dl), len(non_queued_up)
+        is_over_limit = (all_limit and dl_count + up_count >= all_limit and (not state_limit or dl_count >= state_limit)) or (state_limit and dl_count >= state_limit)
+        if is_over_limit:
+            if mid in queued_dl or mid in queued_up:
+                LOGGER.info(f"Task {mid} already queued, skipping")
+                return is_over_limit, event
+            event = Event()
+            if state == 'dl':
+                queued_dl[mid] = event
+            else:
+                queued_up[mid] = event
     return is_over_limit, event
 
 

--- a/bot/helper/listeners/tasks_listener.py
+++ b/bot/helper/listeners/tasks_listener.py
@@ -37,7 +37,6 @@ from bot.helper.video_utils.processor import process_video
 class TaskListener(TaskConfig):
     def __init__(self):
         super().__init__()
-        self.completed = False
 
     @staticmethod
     async def clean():
@@ -60,9 +59,12 @@ class TaskListener(TaskConfig):
             await DbManager().add_incomplete_task(self.message.chat.id, self.message.link, self.tag)
 
     async def onDownloadComplete(self):
-        if self.completed:
-            return
-        self.completed = True
+        async with task_dict_lock:
+            if self.mid in task_dict:
+                if hasattr(task_dict[self.mid], 'completed') and task_dict[self.mid].completed:
+                    LOGGER.info(f"Skipping already completed task: {self.mid}")
+                    return
+                setattr(task_dict[self.mid], 'completed', True)
         multi_links = False
         if self.sameDir and self.mid in self.sameDir['tasks']:
             while not (self.sameDir['total'] in [1, 0] or self.sameDir['total'] > 1 and len(self.sameDir['tasks']) > 1):

--- a/bot/helper/mirror_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_utils/upload_utils/telegram_uploader.py
@@ -44,7 +44,7 @@ class TgUploader:
         self._send_msg = None
         self._up_path = ''
         self._leech_log = config_dict['LEECH_LOG']
-        self.uploaded_files = set()
+        self._uploaded_files = set()
 
     async def _upload_progress(self, current, _):
         if self._is_cancelled:
@@ -62,7 +62,8 @@ class TgUploader:
                 continue
             for file_ in natsorted(files):
                 self._up_path = ospath.join(dirpath, file_)
-                if self._up_path in self.uploaded_files:
+                if file_ in self._uploaded_files:
+                    LOGGER.info(f"Skipping already uploaded file: {file_}")
                     continue
                 if file_.lower().endswith(tuple(self._listener.extensionFilter)) or file_.startswith('Thumb'):
                     if not file_.startswith('Thumb'):
@@ -90,7 +91,7 @@ class TgUploader:
                     self._last_msg_in_group = False
                     self._last_uploaded = 0
                     await self._upload_file(caption, file_)
-                    self.uploaded_files.add(self._up_path)
+                    self._uploaded_files.add(file_)
                     total_files += 1
                     if self._is_cancelled:
                         return


### PR DESCRIPTION
This commit addresses several issues that could cause tasks to become unresponsive or behave incorrectly.

- Fixed a potential deadlock in the ffmpeg process.
- Added idempotency checks to prevent duplicate task processing.
- Added a check to prevent re-uploading the same file.
- Added a new 'Processing' status for video tasks.
- Made thumbnail extraction more robust.