### PR TITLE
Fix critical bugs and enhance video processing logic.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN chmod 777 /usr/src/app
 COPY requirements.txt .
 RUN pip3 install --upgrade setuptools wheel
 RUN pip3 install --no-cache-dir -r requirements.txt
+RUN apt-get update && apt-get install -y openjdk-17-jre-headless
 
 COPY . .
 


### PR DESCRIPTION
This commit addresses two critical bugs and finalizes the implementation of the new video processing and UI features.

Bug Fixes:
- **FFMpeg In-Place Error:** The video processor has been modified to use a temporary output file (`.processed.mkv`) to prevent `ffmpeg` from failing when the input and output filenames are the same. The processed file is then renamed back to its final name.
- **JDownloader Startup Crash:** The `Dockerfile` has been updated to install the `openjdk-17-jre-headless` package, which provides the Java runtime environment required by JDownloader, fixing the `java: not found` error.
- **Circular Import Crash:** A circular dependency between `status_utils.py` and `video_status.py` was resolved by moving the `MirrorStatus` class to a dedicated `status_constants.py` file.

Features & Enhancements:
- The `ffmpeg` command logic has been completely refactored to be more robust, using language-based mapping and safety flags to prevent A/V sync issues.
- The UI for completion messages has been significantly improved with a new detailed format for both single and split files.
- Unwanted images have been removed from status messages.