### PR TITLE
Fix: Restore `get_metavideo` function to resolve startup crash.

### DIFF
--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -121,3 +121,23 @@ async def process_video(path, listener):
         return final_path
 
     return None
+
+async def get_metavideo(url):
+    """Get media metadata from a URL using ffprobe."""
+    try:
+        process = await asyncio.create_subprocess_exec(
+            'ffprobe', '-hide_banner', '-loglevel', 'error', '-print_format', 'json',
+            '-show_format', url,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            LOGGER.error(f"ffprobe error for URL {url}: {stderr.decode().strip()}")
+            return None, None
+        media_info = json.loads(stdout)
+        duration = media_info.get('format', {}).get('duration', 0)
+        size = media_info.get('format', {}).get('size', 0)
+        return duration, {'size': size}
+    except Exception as e:
+        LOGGER.error(f"Exception while getting media metadata for URL {url}: {e}")
+        return None, None


### PR DESCRIPTION
The `get_metavideo` function was incorrectly removed from `bot/helper/video_utils/processor.py` during a previous refactoring. This caused an `ImportError` in `bot/modules/media_info.py`, which prevented the bot from starting.

This commit restores the `get_metavideo` function to its original location, fixing the startup crash.