### PR TITLE
Feat: Add diagnostic logging for track removal.

### DIFF
--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -74,6 +74,7 @@ async def process_video(path, listener):
     main_video_streams = [s for s in all_video_streams if not s.get('disposition', {}).get('attached_pic')]
 
     preferred_langs = [lang.strip() for lang in config_dict.get('PREFERRED_LANGUAGES', 'eng,hin,tel').split(',')]
+    LOGGER.info(f"Preferred Languages: {preferred_langs}")
     selected_audio = []
     found_preferred = False
     for lang in preferred_langs:


### PR DESCRIPTION
This commit adds a logging statement to `bot/helper/video_utils/processor.py` to print the list of preferred languages being used for audio track selection.

This is intended to help diagnose a persistent bug where track removal is not behaving as expected. The log output will show whether the configuration is being loaded correctly.