### PR TITLE
Fix: Robustly parse PREFERRED_LANGUAGES configuration.

### DIFF
--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -73,8 +73,9 @@ async def process_video(path, listener):
     art_streams = [s for s in all_video_streams if s.get('disposition', {}).get('attached_pic')]
     main_video_streams = [s for s in all_video_streams if not s.get('disposition', {}).get('attached_pic')]
 
-    preferred_langs = [lang.strip() for lang in config_dict.get('PREFERRED_LANGUAGES', 'eng,hin,tel').split(',')]
-    LOGGER.info(f"Preferred Languages: {preferred_langs}")
+    lang_string = config_dict.get('PREFERRED_LANGUAGES', 'eng,hin,tel')
+    preferred_langs = [lang.strip().strip('"\'') for lang in lang_string.split(',')]
+    LOGGER.info(f"Cleaned Preferred Languages: {preferred_langs}")
     selected_audio = []
     found_preferred = False
     for lang in preferred_langs:


### PR DESCRIPTION
This commit fixes a persistent bug where audio track removal would fail. The root cause was improper parsing of the `PREFERRED_LANGUAGES` environment variable when it contained quotes.

The logic in `processor.py` has been updated to strip whitespace and surrounding quotes from each language code, ensuring that the configuration is parsed correctly. This allows the hierarchical audio selection to work as intended.