### PR TITLE
Fix video processing TypeError and initial ImportError

### DIFF
--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -24,12 +24,13 @@ async def process_video(path, listener):
     """
     metadata = await get_metavideo(path)
     if not metadata or not metadata[0]:
-        listener.onUploadError("Failed to get video metadata.")
+        await listener.onUploadError("Failed to get video metadata.")
         return None
 
+    # Set listener.vidMode to the tuple format expected by the executor
+    listener.vidMode = ('rmstream', listener.name, {})
+
     executor = exc.VidEcxecutor(listener, path, listener.gid)
-    # Set the mode to 'rmstream' for the executor
-    executor.mode = 'rmstream'
 
     selector = ExtraSelect(executor)
     await selector.auto_select(metadata[0]) # metadata[0] contains the streams


### PR DESCRIPTION
This commit addresses two issues:
1. An `ImportError` for `process_video` that caused the bot to crash on startup. This is fixed by re-implementing the function in `processor.py`.
2. A subsequent `TypeError` caused by `listener.vidMode` being a boolean instead of a tuple. This is fixed by ensuring `vidMode` is set to the correct tuple format within the new `process_video` function before it is used by the `VidEcxecutor`.