### PR TITLE
Fix multiple startup errors

### DIFF
--- a/bot/modules/media_info.py
+++ b/bot/modules/media_info.py
@@ -11,7 +11,7 @@ from bot.helper.telegram_helper.bot_commands import BotCommands
 from bot.helper.telegram_helper.button_build import ButtonMaker
 from bot.helper.telegram_helper.filters import CustomFilters
 from bot.helper.telegram_helper.message_utils import sendMessage, sendPhoto, editPhoto, copyMessage, deleteMessage
-from bot.helper.video_utils.processor import get_metavideo
+from bot.helper.video_utils.executor import get_metavideo
 @new_task
 async def medinfo(_, message: Message):
     link, media, cmsg = get_link(message), None, None


### PR DESCRIPTION
This commit resolves a series of cascading errors that prevented the bot from starting.

1.  I re-implemented the `process_video` function in `processor.py`, which was missing, causing an `ImportError`. The new function is non-interactive and uses the modern `ExtraSelect` logic.
2.  I fixed a `TypeError` in the new `process_video` function by ensuring `listener.vidMode` is correctly formatted as a tuple.
3.  I fixed a non-interactive bug by manually setting the executor's event to prevent the interactive UI from being triggered.
4.  I corrected an `ImportError` for `get_metavideo` in `media_info.py` by changing the import path from `processor.py` to `executor.py`.

The `processor.py` file has been updated with a complete, robust version you provided.